### PR TITLE
Fix HEAD build break (#2) + 5 small correctness / cleanup issues (#3)

### DIFF
--- a/components/usbipdcpp/src/esp32_handler/Esp32DeviceHandler.cpp
+++ b/components/usbipdcpp/src/esp32_handler/Esp32DeviceHandler.cpp
@@ -120,7 +120,9 @@ void usbipdcpp::Esp32DeviceHandler::on_new_connection(Session &current_session, 
     // 控制端点 0 的 MPS
     if (handle_device.ep0_in.max_packet_size > 0) {
         endpoint_mps_map_[0x80] = handle_device.ep0_in.max_packet_size;
-        endpoint_mps_map_[0x00] = handle_device.ep0_in.max_packet_size;
+    }
+    if (handle_device.ep0_out.max_packet_size > 0) {
+        endpoint_mps_map_[0x00] = handle_device.ep0_out.max_packet_size;
     }
 }
 

--- a/components/usbipdcpp/src/esp32_handler/Esp32DeviceHandler.cpp
+++ b/components/usbipdcpp/src/esp32_handler/Esp32DeviceHandler.cpp
@@ -554,11 +554,28 @@ int usbipdcpp::Esp32DeviceHandler::tweak_set_interface_cmd(const SetupPacket &se
     uint16_t alternate = setup_packet.value;
 
     SPDLOG_DEBUG("set_interface: inf {} alt {}", interface, alternate);
-    SPDLOG_ERROR("不支持的控制传输 set_interface");
-    ESP_LOGE(TAG, "不支持的控制传输 set_interface");
 
-    // ESP-IDF 暂不支持动态切换 alternate setting
-    return ESP_OK;
+    // ESP-IDF's usb_host_lib does not currently support dynamic alt-setting
+    // switches. Handling depends on the requested alternate:
+    //
+    //   * alt 0 — the interface is already at alt 0 after SET_CONFIGURATION,
+    //     so a client asking for alt 0 is effectively a no-op. Report
+    //     success so standard Linux-kernel enumeration (which issues
+    //     SET_INTERFACE(alt=0) for interfaces with multiple alt-settings)
+    //     proceeds cleanly.
+    //
+    //   * alt != 0 — we cannot honor the request. Previously this returned
+    //     ESP_OK and the client believed the switch succeeded, which is
+    //     silent data corruption for devices that have meaningful
+    //     alt-settings (UVC cameras, class-compound audio devices, etc.).
+    //     Return an error instead so the client sees the failure.
+    if (alternate == 0) {
+        SPDLOG_DEBUG("set_interface alt=0 treated as no-op (already at default alt)");
+        return ESP_OK;
+    }
+    SPDLOG_ERROR("set_interface alt={} not supported by ESP-IDF usb_host_lib", alternate);
+    ESP_LOGE(TAG, "set_interface alt=%u not supported by ESP-IDF usb_host_lib", alternate);
+    return ESP_ERR_NOT_SUPPORTED;
 }
 
 int usbipdcpp::Esp32DeviceHandler::tweak_set_configuration_cmd(const SetupPacket &setup_packet) {

--- a/components/usbipdcpp/src/esp32_handler/Esp32DeviceHandler.cpp
+++ b/components/usbipdcpp/src/esp32_handler/Esp32DeviceHandler.cpp
@@ -299,7 +299,10 @@ void usbipdcpp::Esp32DeviceHandler::handle_bulk_transfer(std::uint32_t seqnum, c
     trx->num_bytes = aligned_length;
     trx->flags = get_esp32_transfer_flags(transfer_flags);
     if (is_out) {
-        trx->flags &= USB_TRANSFER_FLAG_ZERO_PACK;
+        // On bulk OUT, USB_TRANSFER_FLAG_ZERO_PACK asks the host to append a
+        // zero-length packet when the payload is an exact multiple of the
+        // endpoint MPS, so the device sees a clean end-of-transfer marker.
+        trx->flags |= USB_TRANSFER_FLAG_ZERO_PACK;
     }
 
     transfer_tracker_.register_transfer(seqnum, trx, ep.address);

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRCS "esp32_usbipdcpp.cpp"
-                    INCLUDE_DIRS "." include
+                    INCLUDE_DIRS "."
                     PRIV_REQUIRES asio spdlog nvs_flash esp_wifi pthread usb usbipdcpp)
 #target_compile_definitions(main PRIVATE SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
 add_compile_definitions(

--- a/main/esp32_usbipdcpp.cpp
+++ b/main/esp32_usbipdcpp.cpp
@@ -189,25 +189,6 @@ void init_all() {
     init_usb_host();
 }
 
-asio::awaitable<void> handle_connection(asio::ip::tcp::socket &&socket) {
-    while (true) {
-        try {
-            std::array<char, 1> buffer{};
-            co_await asio::async_read(socket, asio::buffer(buffer), asio::use_awaitable);
-            co_await asio::async_write(socket, asio::buffer(buffer), asio::use_awaitable);
-        } catch (std::exception &e) {
-            ESP_LOGE(TAG, "socket exception occurs: %s", e.what());
-            break;
-        }
-    }
-    std::error_code ignore_ec;
-    ESP_LOGI(TAG, "尝试关闭socket");
-    socket.shutdown(asio::ip::tcp::socket::shutdown_both, ignore_ec);
-    socket.close(ignore_ec);
-
-    co_return;
-}
-
 using namespace usbipdcpp;
 
 int thread_main() {

--- a/main/esp32_usbipdcpp.cpp
+++ b/main/esp32_usbipdcpp.cpp
@@ -20,7 +20,6 @@
 #include <pthread.h>
 
 #include "esp32_handler/Esp32Server.h"
-#include "mock_mouse.h"
 
 
 using namespace std;

--- a/main/esp32_usbipdcpp.cpp
+++ b/main/esp32_usbipdcpp.cpp
@@ -1,5 +1,6 @@
 #include "sdkconfig.h"
 
+#include <cstring>
 #include <iostream>
 #include <thread>
 #include <semaphore>
@@ -214,7 +215,11 @@ int thread_main() {
     init_all();
 
     ESP_LOGI(TAG, "连接wifi ssid:%s", wifi_ssid);
-    ESP_LOGI(TAG, "连接wifi password:%s", wifi_passwd);
+    // The password is intentionally not logged — serial logs are often shared
+    // (in issue reports, screen shares, crash dumps) and this would leak the
+    // WiFi credential. If you need to verify the configured password for
+    // debugging, read CONFIG_USBIPD_WIFI_PASSWORD from sdkconfig directly.
+    ESP_LOGI(TAG, "连接wifi password: <redacted, length=%d>", (int)strlen(wifi_passwd));
 
     spdlog::set_level(spdlog::level::trace);
 


### PR DESCRIPTION
Seven small commits, each addressing a separate issue, cherry-pickable in any order (there are no inter-dependencies except that the two build-break commits are needed together to produce a buildable tree).

Closes #2 (build break) and #3 (code review findings).

### Commits

1. **Remove dead `mock_mouse.h` include from `main/esp32_usbipdcpp.cpp`** — the header lives in the nested submodule at `components/usbipdcpp/usbipdcpp/examples/mock_mouse/` and isn't on main's include path; every use in the file is already `//`-commented out. Fixes part of #2.
2. **Drop non-existent `include/` dir from `main`'s `INCLUDE_DIRS`** — `main/include/` does not exist in the repo; CMake refuses to configure. Fixes part of #2.
3. **Do not log WiFi password in plaintext on every boot** — addresses #3 issue A. Redacts value, logs length only.
4. **Fix `&=`/`|=` typo on bulk OUT ZERO_PACK flag** — addresses #3 issue B. `&=` was masking off every flag except `ZERO_PACK`; use `|=` to add the bit as intended.
5. **Use `ep0_out` MPS for endpoint `0x00` entry** — addresses #3 issue D. Copy-paste typo; benign today but wrong.
6. **`tweak_set_interface_cmd`: succeed only for `alt == 0`, error otherwise** — addresses #3 issue C. Previously silently lied to the client for `alt != 0`. Now: `alt == 0` → `ESP_OK` (keeps standard Linux enumeration working); `alt != 0` → `ESP_ERR_NOT_SUPPORTED` so the client sees the failure instead of acting on a wrong assumption.
7. **Remove dead `handle_connection` echo coroutine** — addresses #3 issue E. Leftover prototyping code, never called.

### How this was tested

Built the branch on ESP-IDF v5.5.4 for ESP32-S3 with:

```
idf.py -DSDKCONFIG_DEFAULTS="sdkconfig.defaults.esp32s3" set-target esp32s3
idf.py build
```

Clean build, no warnings beyond the pre-existing ones. Flashed on a genuine Espressif ESP32-S3-DevKitC-1-N8R8; board boots, connects WiFi, USBIP server listens on `:3240`. `usbip list -r <ip>` from a Linux client handshakes correctly and reports "no exportable devices found" (expected — no device on the native USB port yet).

### Things I did *not* touch

- Two more findings from the review (`std::exit(1)` in exception handlers, and the wifi-reconnect thread not being cleanly stoppable) are design-level, not trivial one-liners — I'd rather discuss those separately than sneak them into a bug-fix PR.
- No formatting/whitespace-only changes.
- Submodule pointer is unchanged.

Happy to rework any of these however you prefer, or to split / squash differently.