### PR TITLE
fix: don't clear callback_args_pool on session disconnect

### DIFF
--- a/components/usbipdcpp/src/esp32_handler/Esp32DeviceHandler.cpp
+++ b/components/usbipdcpp/src/esp32_handler/Esp32DeviceHandler.cpp
@@ -149,7 +149,11 @@ void usbipdcpp::Esp32DeviceHandler::on_disconnection(error_code &ec) {
         });
     }
 
-    callback_args_pool_.clear();
+    // Note: callback_args_pool_ is intentionally NOT cleared here. ObjectPool::clear()
+    // permanently destroys all preallocated slots and there is no re-init path, so
+    // clearing on session disconnect would force every subsequent alloc() in a
+    // following session to fall back to heap `new`, defeating the purpose of the pool.
+    // The pool's lifetime matches the handler's; its destructor releases the slots.
     AbstDeviceHandler::on_disconnection(ec);
 }
 


### PR DESCRIPTION
## The bug

`Esp32DeviceHandler::on_disconnection` calls `callback_args_pool_.clear()` at the end of every USBIP session teardown. `ObjectPool::clear()` (in `components/usbipdcpp/usbipdcpp/include/utils/ObjectPool.h`) is a one-shot teardown operation: it `delete`s every preallocated `T*`, sets each `pool_[i] = {nullptr, false}`, and zeros `free_top_`. There is no public re-init method, and `on_new_connection` does not rebuild the slots.

The consequence is that `alloc_impl()` short-circuits on the very next allocation:

```cpp
T *alloc_impl() {
    if (free_top_ == 0) {
        return nullptr;
    }
    ...
}
```

Every call site of `callback_args_pool_.alloc()` then falls back to heap `new`:

```cpp
auto *callback_args = callback_args_pool_.alloc();
if (!callback_args) [[unlikely]] {
    callback_args = new esp32_callback_args{};
}
```

So after the *first* USBIP session, the pool is permanently dead and 100% of allocations go through `new`/`delete` — exactly what the preallocated pool exists to avoid. The fallback path is correct, just slow and allocation-heavy in the URB hot path.

## Empirical confirmation

Adding a counter on the fallback branch (`callback_args_pool_.alloc() == nullptr`) across 5 sequential USBIP sessions on the same handler: 0 allocations went to fallback in session 1, then 100% in every following session. The peak number of concurrent in-flight URBs stayed at 3 throughout, so the 64-slot pool was never anywhere near its capacity — the only reason allocs were failing was that `clear()` had wiped it.

## The fix

Remove the `callback_args_pool_.clear()` call. The pool's lifetime should match the handler's, not the session's: the handler is created when the device is enumerated and destroyed when the device is removed (via `Esp32Server`'s device-management map). `ObjectPool`'s destructor still calls `clear_impl()` on handler destruction, so memory cleanup remains correct.